### PR TITLE
[ DEPLOY ] [ 2.2.0 ] Download feature and some fixes

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,4 @@
 {
-    "python.analysis.typeCheckingMode": "basic"
+    "python.analysis.typeCheckingMode": "basic",
+    "cloudcode.duetAI.inlineSuggestions.enableAuto": false
 }

--- a/README.md
+++ b/README.md
@@ -41,7 +41,8 @@ Feature   | NHentai | Manganato
 search    |    ✅   |     ✅    
 random    |    ✅   |     🚫    
 get       |    ✅   |     ✅    
-paginate  |    ✅   |     🚫    
+paginate  |    ✅   |     🚫
+download  |    ✅   |     ✅       
 set_config|    ✅   |     🚫
 
 ## Usage
@@ -85,6 +86,29 @@ enma.source_manager.set_source(source_name=AvailableSources.MANGANATO)
 
 manga = enma.random()
 print(manga)
+```
+
+### Example 3: Downloading Chapters
+```py
+from enum import Enum
+from enma import Enma, SourcesEnum, Manganato, IMangaRepository, default_downloader
+
+enma = Enma()
+
+enma.source_manager.set_source('nhentai')
+
+if enma.source_manager.source:
+    config = CloudFlareConfig(
+        user_agent='Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/117.0.0.0 Safari/537.36',
+        cf_clearance=''
+    )
+
+    enma.source_manager.source.set_config(config=config)
+
+manga = enma.random()
+manga.chapters[0].download(downloader=default_downloader)
+# or manga.chapters[0].download(downloader=default_downloader, output_path='./naruto/chapters/01')
+
 ```
 
 ## Retrieving `user-agent` and `cf_clearance` for NHentai
@@ -137,6 +161,10 @@ While using the library, you might encounter some specific errors. Here's a desc
 5. **NhentaiSourceWithoutConfig**: 
    - **Description**: Raised when trying to make a request to NHentai without providing the necessary configurations.
    - **Common Cause**: Forgetting to provide the `user-agent` and `cf_clearance` when configuring the NHentai adapter.
+
+6. **InvalidResource**: 
+   - **Description**: Raised when trying to perform an action with an invalid or inexistent resource.
+   - **Common Cause**: Providing an inexistent folder path to downloader.
 
 When encountering one of these errors, refer to the description and common cause to assist in troubleshooting.
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![PyPI download month](https://img.shields.io/pypi/dm/NHentai-API.svg)](https://pypi.python.org/pypi/NHentai-API/)
+[![PyPI download month](https://img.shields.io/pypi/dm/Enma.svg)](https://pypi.python.org/pypi/Enma/)
 [![codecov](https://codecov.io/gh/AlexandreSenpai/Enma/branch/master/graph/badge.svg?token=F3LP15DYMR)](https://codecov.io/gh/AlexandreSenpai/Enma)
 [![Python 3.9+](https://img.shields.io/badge/Python-3.9+-blue.svg)](https://www.python.org/downloads/release/python-390/)
 [![PyPI license](https://img.shields.io/pypi/l/ansicolortags.svg)](https://pypi.python.org/pypi/ansicolortags/)

--- a/enma/__init__.py
+++ b/enma/__init__.py
@@ -2,6 +2,8 @@ import sys
 from enma.infra.entrypoints.lib import Enma, SourcesEnum, DefaultAvailableSources
 from enma.infra.adapters.repositories.nhentai import CloudFlareConfig, NHentai, Sort
 from enma.infra.adapters.repositories.manganato import Manganato
+from enma.infra.adapters.downloaders.default import default_downloader
+from enma.infra.adapters.downloaders.manganato import manganato_downloader
 
 __version__ = '2.0.0'
 

--- a/enma/__init__.py
+++ b/enma/__init__.py
@@ -1,5 +1,5 @@
 import sys
-from enma.infra.entrypoints.lib import Enma, SourcesEnum
+from enma.infra.entrypoints.lib import Enma, SourcesEnum, DefaultAvailableSources
 from enma.infra.adapters.repositories.nhentai import CloudFlareConfig, NHentai, Sort
 from enma.infra.adapters.repositories.manganato import Manganato
 

--- a/enma/application/core/handlers/error.py
+++ b/enma/application/core/handlers/error.py
@@ -7,6 +7,15 @@ class SourceNotAvailable(Exception):
         self.desc: str = 'This error occurs when the client chooses nonexistent source.'
         self.critical: bool = False
 
+class InvalidResource(Exception):
+    def __init__(self, message: str) -> None:
+        super().__init__(message)
+
+        self.message: str = message
+        self.code: str = 'INVALID_RESOURCE'
+        self.desc: str = 'This error occurs when the client tries to perform an action with an invalid resource.'
+        self.critical: bool = True
+
 class NhentaiSourceWithoutConfig(Exception):
     def __init__(self, message: str) -> None:
         super().__init__(message)

--- a/enma/application/core/interfaces/manga_repository.py
+++ b/enma/application/core/interfaces/manga_repository.py
@@ -1,10 +1,17 @@
 from abc import ABC, abstractmethod
+from typing import Any
 
 from enma.domain.entities.manga import Manga
 from enma.domain.entities.pagination import Pagination
 from enma.domain.entities.search_result import SearchResult
 
 class IMangaRepository(ABC):
+
+    @abstractmethod
+    def set_config(self, 
+                   config: Any) -> None:
+        ...
+
     @abstractmethod
     def get(self,
             identifier: str) -> Manga | None:

--- a/enma/domain/core/interfaces/downloader.py
+++ b/enma/domain/core/interfaces/downloader.py
@@ -1,0 +1,4 @@
+from typing import Callable, TypeAlias
+
+
+IDownloader: TypeAlias = Callable[[str, str], None]

--- a/enma/infra/adapters/downloaders/default.py
+++ b/enma/infra/adapters/downloaders/default.py
@@ -1,0 +1,8 @@
+import requests
+
+
+def default_downloader(uri: str, output_path: str) -> None:
+    with open(output_path, 'wb') as f:
+        for chunk in requests.get(uri, stream=True).iter_content(chunk_size=1024):
+            if chunk:
+                f.write(chunk)

--- a/enma/infra/adapters/downloaders/manganato.py
+++ b/enma/infra/adapters/downloaders/manganato.py
@@ -1,0 +1,9 @@
+import requests
+
+def manganato_downloader(uri: str, output_path: str) -> None:
+    with open(output_path, 'wb') as f:
+        for chunk in requests.get(url=uri, 
+                                  stream=True, 
+                                  headers={'Referer': 'https://chapmanganato.com/'}).iter_content(chunk_size=1024):
+            if chunk:
+                f.write(chunk)

--- a/enma/infra/adapters/repositories/manganato.py
+++ b/enma/infra/adapters/repositories/manganato.py
@@ -145,7 +145,10 @@ class Manganato(IMangaRepository):
                             results=thumbs)
 
     def paginate(self, page: int) -> Pagination:
-        return super().paginate(page)
+        raise NotImplementedError('Paginate is not yet implemented.')
     
     def random(self) -> Manga:
-        return super().random()
+        raise NotImplementedError('Random is not yet implemented.')
+    
+    def set_config(self, **kwargs) -> None:
+        raise NotImplementedError('Manganato does not support set_config')

--- a/enma/infra/adapters/repositories/nhentai.py
+++ b/enma/infra/adapters/repositories/nhentai.py
@@ -73,7 +73,7 @@ class NHentai(IMangaRepository):
 
     def get(self, identifier: str) -> Manga | None:
         response = self.__make_request(url=f'{self.__API_URL}/gallery/{identifier}')
-        
+
         if response.status_code != 200:
             return
         

--- a/enma/infra/adapters/repositories/nhentai.py
+++ b/enma/infra/adapters/repositories/nhentai.py
@@ -89,6 +89,7 @@ class NHentai(IMangaRepository):
                                                   mime=MIME[doujin.get("images").get("thumbnail").get("t").upper()],
                                                   media_id=doujin.get('media_id'),
                                                   page_number=index+1),
+                         mime=MIME[doujin.get("images").get("thumbnail").get("t").upper()],
                          width=page.get('w'),
                          height=page.get('h'))
 
@@ -106,11 +107,13 @@ class NHentai(IMangaRepository):
                       thumbnail=Image(uri=self.__make_page_uri(type='thumbnail',
                                                                mime=MIME[doujin.get("images").get("thumbnail").get("t").upper()],
                                                                media_id=doujin.get('media_id')),
+                                      mime=MIME[doujin.get("images").get("thumbnail").get("t").upper()],
                                       width=doujin.get("images").get("thumbnail").get("w"),
                                       height=doujin.get("images").get("thumbnail").get("h")),
                       cover=Image(uri=self.__make_page_uri(type='cover',
                                                             media_id=doujin.get('media_id'),
                                                             mime=MIME[doujin.get("images").get("thumbnail").get("t").upper()]),
+                                  mime=MIME[doujin.get("images").get("thumbnail").get("t").upper()],
                                   width=doujin.get("images").get("cover").get("w"),
                                   height=doujin.get("images").get("cover").get("h")),
                       chapters=[chapter])
@@ -180,6 +183,7 @@ class NHentai(IMangaRepository):
 
             thumbs.append(Thumb(id=doujin_id,
                                 cover=Image(uri=cover_uri or '',
+                                            mime=MIME.J,
                                             width=width or 0,
                                             height=height or 0),
                                 title=caption or ''))
@@ -211,6 +215,7 @@ class NHentai(IMangaRepository):
                                          cover=Image(uri=self.__make_page_uri(type='cover',
                                                                               media_id=result.get('media_id'),
                                                                               mime=MIME[result.get('images').get('cover').get('t').upper()]),
+                                                     mime=MIME[result.get("images").get("thumbnail").get("t").upper()],
                                                      width=result.get('images').get('cover').get('w'),
                                                      height=result.get('images').get('cover').get('h'))) for result in data.get('result')])
 

--- a/enma/infra/entrypoints/lib/__init__.py
+++ b/enma/infra/entrypoints/lib/__init__.py
@@ -35,7 +35,7 @@ class SourceManager(Generic[AvailableSources]):
     def __init__(self, **kwargs) -> None:
         self.__SOURCES: dict[str, IMangaRepository] = {'nhentai': NHentai(config=kwargs.get('cloudflare_config')),
                                                        'manganato': Manganato()}
-        self.source = None
+        self.source: IMangaRepository | None = None
         self.source_name = ''
     
     def get_source(self,

--- a/setup.py
+++ b/setup.py
@@ -1,74 +1,14 @@
-from setuptools import setup
-import os
+from setuptools import setup, find_packages
 
 def readme():
     with open('./README.md', 'r') as readme:
         return readme.read()
 
-def make_setup(env_name: str, version: str):
-    if env_name == 'prd':
-        return setup(
-            name='NHentai-API',
-            version=version,
-            description='NHentai Python API made using webscraping.',
-            long_description=readme(),
-            long_description_content_type='text/markdown',
-            classifiers=[
-                "Programming Language :: Python :: 3",
-                "License :: OSI Approved :: MIT License",
-                "Operating System :: OS Independent",
-            ],
-            url='https://github.com/AlexandreSenpai/NHentai-API',
-            author='AlexandreSenpai',
-            author_email='alexandrebsramos@hotmail.com',
-            keywords='Tags, hentai, nhentai, nhentai.net, API, NSFW, erohoshi',
-            license='MIT',
-            packages=['NHentai',
-                      'NHentai.core',
-                      'NHentai.core.auth',
-                      'NHentai.core.auth.google',
-                      'NHentai.core.helpers',
-                      'NHentai.core.interfaces',
-                      'NHentai.asynch',
-                      'NHentai.asynch.infra',
-                      'NHentai.asynch.infra.entrypoints',
-                      'NHentai.asynch.infra.adapters',
-                      'NHentai.asynch.infra.adapters.request',
-                      'NHentai.asynch.infra.adapters.request.http',
-                      'NHentai.asynch.infra.adapters.request.http.interfaces',
-                      'NHentai.asynch.infra.adapters.request.http.implementations',
-                      'NHentai.asynch.infra.adapters.repositories',
-                      'NHentai.asynch.infra.adapters.repositories.hentai',
-                      'NHentai.asynch.infra.adapters.repositories.hentai.implementations',
-                      'NHentai.asynch.infra.adapters.brokers',
-                      'NHentai.asynch.infra.adapters.brokers.implementations',
-                      'NHentai.asynch.application',
-                      'NHentai.asynch.application.use_cases',
-                      'NHentai.asynch.infra.entrypoints.lib',
-                      'NHentai.sync',
-                      'NHentai.sync.infra',
-                      'NHentai.sync.infra.entrypoints',
-                      'NHentai.sync.infra.adapters',
-                      'NHentai.sync.infra.adapters.request',
-                      'NHentai.sync.infra.adapters.request.http',
-                      'NHentai.sync.infra.adapters.request.http.interfaces',
-                      'NHentai.sync.infra.adapters.request.http.implementations',
-                      'NHentai.sync.infra.adapters.repositories',
-                      'NHentai.sync.infra.adapters.repositories.hentai',
-                      'NHentai.sync.infra.adapters.repositories.hentai.implementations',
-                      'NHentai.sync.infra.adapters.brokers',
-                      'NHentai.sync.infra.adapters.brokers.implementations',
-                      'NHentai.sync.application',
-                      'NHentai.sync.application.use_cases',
-                      'NHentai.sync.infra.entrypoints.lib'],
-            install_requires=['requests', 'beautifulsoup4', 'aiohttp', 'expiringdict', 'google-cloud-pubsub', 'google-auth'],
-            include_package_data=True,
-            zip_safe=False
-        )
+def make_setup():
     return setup(
-        name='dev-nhentai-build',
-        version=version,
-        description='NHentai Python API made using webscraping.',
+        name='Enma',
+        version="2.0.2",
+        description='Enma is a Python library designed to fetch manga and doujinshi data from various sources.',
         long_description=readme(),
         long_description_content_type='text/markdown',
         classifiers=[
@@ -76,57 +16,16 @@ def make_setup(env_name: str, version: str):
             "License :: OSI Approved :: MIT License",
             "Operating System :: OS Independent",
         ],
-        url='https://github.com/AlexandreSenpai/NHentai-API',
+        url='https://github.com/AlexandreSenpai/Enma',
         author='AlexandreSenpai',
         author_email='alexandrebsramos@hotmail.com',
-        keywords='Tagshentai, nhentai, nhentai.net, API, NSFW',
+        keywords='Tags, hentai, nhentai, nhentai.net, API, NSFW, erohoshi, Manganato, Doujinshi, Manga, Scrapper',
         license='MIT',
-        packages=['NHentai',
-                  'NHentai.core',
-                  'NHentai.core.auth',
-                  'NHentai.core.auth.google',
-                  'NHentai.core.helpers',
-                  'NHentai.core.interfaces',
-                  'NHentai.asynch',
-                  'NHentai.asynch.infra',
-                  'NHentai.asynch.infra.entrypoints',
-                  'NHentai.asynch.infra.adapters',
-                  'NHentai.asynch.infra.adapters.request',
-                  'NHentai.asynch.infra.adapters.request.http',
-                  'NHentai.asynch.infra.adapters.request.http.interfaces',
-                  'NHentai.asynch.infra.adapters.request.http.implementations',
-                  'NHentai.asynch.infra.adapters.repositories',
-                  'NHentai.asynch.infra.adapters.repositories.hentai',
-                  'NHentai.asynch.infra.adapters.repositories.hentai.implementations',
-                  'NHentai.asynch.infra.adapters.brokers',
-                  'NHentai.asynch.infra.adapters.brokers.implementations',
-                  'NHentai.asynch.application',
-                  'NHentai.asynch.application.use_cases',
-                  'NHentai.asynch.infra.entrypoints.lib',
-                  'NHentai.sync',
-                  'NHentai.sync.infra',
-                  'NHentai.sync.infra.entrypoints',
-                  'NHentai.sync.infra.adapters',
-                  'NHentai.sync.infra.adapters.request',
-                  'NHentai.sync.infra.adapters.request.http',
-                  'NHentai.sync.infra.adapters.request.http.interfaces',
-                  'NHentai.sync.infra.adapters.request.http.implementations',
-                  'NHentai.sync.infra.adapters.repositories',
-                  'NHentai.sync.infra.adapters.repositories.hentai',
-                  'NHentai.sync.infra.adapters.repositories.hentai.implementations',
-                  'NHentai.sync.infra.adapters.brokers',
-                  'NHentai.sync.infra.adapters.brokers.implementations',
-                  'NHentai.sync.application',
-                  'NHentai.sync.application.use_cases',
-                  'NHentai.sync.infra.entrypoints.lib'],
-        install_requires=['requests', 'beautifulsoup4', 'aiohttp', 'expiringdict', 'google-cloud-pubsub', 'google-auth'],
-        include_dirs=True,
+        packages=find_packages(),
+        install_requires=['requests', 'beautifulsoup4'],
         include_package_data=True,
         zip_safe=False
     )
 
 if __name__ == '__main__':
-    env = os.getenv('NHENTAI_ENVIRONMENT', 'dev')
-    version = os.getenv('NHENTAI_VERSION', '1.0.2')
-    print(f'TARGET_ENVIRONMENT: {env}\nTARGET_VERSION: {version}')
-    make_setup(env, version)
+    make_setup()

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ def readme():
 def make_setup():
     return setup(
         name='Enma',
-        version="2.0.2",
+        version="2.1.2",
         description='Enma is a Python library designed to fetch manga and doujinshi data from various sources.',
         long_description=readme(),
         long_description_content_type='text/markdown',


### PR DESCRIPTION
Thanks to @Nega-ve for fixing created/update dates.
This PR brings the download feature for nhentai and manganato default sources.

You can download the new version running

```sh
pip3 install --upgrade enma
# or
pip3 install enma==2.2.0
```