### PR TITLE
fix: add encoding when opening readme

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 from setuptools import setup, find_packages
 
 def readme():
-    with open('./README.md', 'r') as readme:
+    with open('./README.md', 'r', encoding='utf-8') as readme:
         return readme.read()
 
 def make_setup():


### PR DESCRIPTION
I am using Windows 10 in Simplified Chinese (gbk encoding in cmd). 

No matter run `pip install enma` or run `python setup.py bdist_wheel` after cloning the project, there is always an exception:
```
(venv) C:\Users\Elnino\Desktop\test\Enma>python setup.py bdist_wheel
Traceback (most recent call last):
  File "C:\Users\Elnino\Desktop\test\Enma\setup.py", line 31, in <module>
    make_setup()
  File "C:\Users\Elnino\Desktop\test\Enma\setup.py", line 12, in make_setup
    long_description=readme(),
                     ^^^^^^^^
  File "C:\Users\Elnino\Desktop\test\Enma\setup.py", line 5, in readme
    return readme.read()
           ^^^^^^^^^^^^^
UnicodeDecodeError: 'gbk' codec can't decode byte 0x85 in position 1708: illegal multibyte sequence
```
The solution is quite simple in my opinion: open with encoding  utf-8. And it works.