### PR TITLE
Fixed bugs in repositories/manganato.py

### DIFF
--- a/enma/infra/adapters/repositories/manganato.py
+++ b/enma/infra/adapters/repositories/manganato.py
@@ -45,6 +45,15 @@ class Manganato(IMangaRepository):
                        main_title: str, 
                        alternative: str) -> Title:
         logger.debug(f'Building manga title main: {main_title} and alternative: {alternative}')
+
+        has_many_alternatives = alternative.find(';') != -1 or alternative.find(',') != -1
+
+        if not has_many_alternatives:
+            jp = alternative
+            return Title(english=main_title.strip(),
+                         japanese=jp.strip(),
+                         other=main_title.strip())
+
         jp, cn, *_ = alternative.split(';') if alternative.find(';') != -1 else alternative.split(',')
         return Title(english=main_title.strip(),
                      japanese=jp.strip(),
@@ -149,8 +158,8 @@ class Manganato(IMangaRepository):
                      authors=[Author(name=author)] if author is not None else None,
                      genres=[Genre(name=genre_name) for genre_name in genres],
                      id=identifier,
-                     created_at=datetime.strptime(updated_at, "%b %d,%Y - %I:%M %p") if updated_at else None,
-                     updated_at=datetime.strptime(updated_at, "%b %d,%Y - %I:%M %p") if updated_at else None,
+                     created_at=datetime.strptime(updated_at, "%b %d,%Y - %H:%M %p") if updated_at else None,
+                     updated_at=datetime.strptime(updated_at, "%b %d,%Y - %H:%M %p") if updated_at else None,
                      thumbnail=Image(uri=cover), # type: ignore
                      cover=Image(uri=cover), # type: ignore
                      chapters=chapters) # type: ignore


### PR DESCRIPTION
## Issues with the Manganato repository source

### Issues

1. In the ``get`` method, the format string "%b %d,%Y - %I:%M %p" expects the hour to be in the 12-hour format. However, Manganato displays time in the 24-hour format, which triggers a ValueError exception.

```python

from enma import Enma, DefaultAvailableSources

enma = Enma[DefaultAvailableSources]()
enma.source_manager.set_source("manganato")

test = enma.get(identifier="manga-um997395")

r"""
  File "D:\Archivos de Usuario\Escritorio\Stuff\Projects\external\Enma\enma\infra\adapters\repositories\manganato.py", line 152, in get
    created_at=datetime.strptime(updated_at, "%b %d,%Y - %I:%M %p") if updated_at else None,
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "D:\Archivos de Programas\Python 3.11.2\Lib\_strptime.py", line 568, in _strptime_datetime
    tt, fraction, gmtoff_fraction = _strptime(data_string, format)
                                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "D:\Archivos de Programas\Python 3.11.2\Lib\_strptime.py", line 349, in _strptime
    raise ValueError("time data %r does not match format %r" %
ValueError: time data 'Mar 08,2024 - 14:47 PM' does not match format '%b %d,%Y - %I:%M %p'
"""

```

2. The ``__create_title`` method assumes that the manga title will contain at least two alternatives. However, certain posts in Manganato have a singular alternative. Trying to unpack the values triggers a ValueError exception.

```python
from enma import Enma, DefaultAvailableSources

enma = Enma[DefaultAvailableSources]()
enma.source_manager.set_source("manganato")

test = enma.get(identifier="manga-dj980492")

r"""
  File "D:\Archivos de Usuario\Escritorio\Stuff\Projects\external\Enma\enma\infra\adapters\repositories\manganato.py", line 124, in get
    title = self.__create_title(main_title=elem_title,
            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "D:\Archivos de Usuario\Escritorio\Stuff\Projects\external\Enma\enma\infra\adapters\repositories\manganato.py", line 48, in __create_title
    jp, cn, *_ = alternative.split(';') if alternative.find(';') != -1 else alternative.split(',')
    ^^^^^^^^^^
ValueError: not enough values to unpack (expected at least 2, got 1)
"""
```

### Proposed solutions

1. Change the format string from "%b %d,%Y - %I:%M %p" to "%b %d,%Y - %H:%M %p" to accept 24-hour formatted data.

2. Add a check to see whether there are no multiple available alternative strings, and act accordingly.

```python
has_many_alternatives = alternative.find(';') != -1 or alternative.find(',') != -1

if not has_many_alternatives:
    jp = alternative
    return Title(english=main_title.strip(),
                 japanese=jp.strip(),
                 other=main_title.strip())
```
